### PR TITLE
Added timestamp to positionBalances

### DIFF
--- a/Overtime/schema.graphql
+++ b/Overtime/schema.graphql
@@ -101,6 +101,7 @@ type PositionBalance @entity {
   amount: BigInt!
   position: Position!
   sUSDPaid: BigInt!
+  timestamp: BigInt!
   claimed: Boolean!
 }
 

--- a/Overtime/src/amm-mapping.ts
+++ b/Overtime/src/amm-mapping.ts
@@ -40,6 +40,7 @@ export function handleBoughtFromAmmEvent(event: BoughtFromAmm): void {
         userBalanceFrom.amount = BigInt.fromI32(0);
         userBalanceFrom.position = position.id;
         userBalanceFrom.sUSDPaid = BigInt.fromI32(0);
+        userBalanceFrom.timestamp = event.block.timestamp;
         userBalanceFrom.claimed = false;
       }
 
@@ -96,6 +97,7 @@ export function handleSoldToAMMEvent(event: SoldToAMM): void {
         userBalanceFrom.amount = BigInt.fromI32(0);
         userBalanceFrom.position = position.id;
         userBalanceFrom.sUSDPaid = BigInt.fromI32(0);
+        userBalanceFrom.timestamp = event.block.timestamp;
         userBalanceFrom.claimed = false;
       }
 


### PR DESCRIPTION
As integrators of Overtime protocol, we really need to have an ability to query all of the ticket data based on certain time range. This update will allow us to do so, by adding `timestamp` property to the existing `positionBalance` entity.